### PR TITLE
remove organization application

### DIFF
--- a/gsoc2015.md
+++ b/gsoc2015.md
@@ -20,7 +20,6 @@ We will also host blogs for OpenAstronomy GSoC students on this site.
 * [Project Ideas Page](/gsoc2015/ideas.html)
 * [OpenAstronomy Student Guide](/gsoc2015/student_guidelines.html)
 * [GSoC Student Guide]
-* [OpenAstronomy Application](/gsoc2015/org_application.html)
 
 ## Blog Entries
 

--- a/gsoc2015/org_application.md
+++ b/gsoc2015/org_application.md
@@ -1,7 +1,0 @@
----
-layout: default
-title:  "OpenAstronomy Organisation Application 2015"
-show_main: false
----
-
-Application goes here...


### PR DESCRIPTION
This PR removes the "organization application" part of the site.  I think this might be better just because that way it isn't duplicated in two different places (which invariably get out-of-sync).  But that's not a strong opinion - think of this PR as just a suggestion.

cc @dpshelio @Cadair 