### PR TITLE
Update astropy ideas_team to include affiliated package

### DIFF
--- a/gsoc/gsoc2016/ideas_astropy.md
+++ b/gsoc/gsoc2016/ideas_astropy.md
@@ -2,7 +2,7 @@
 layout: default
 title:  "Ideas for Astropy"
 show_main: false
-ideas_team: Astropy core package
+ideas_team: Astropy
 ---
 
 ### Implement Scheduling capabilities for Astroplan


### PR DESCRIPTION
@eteq - the current `ideas_team` is "Astropy core package", but I think we want it to be just "Astropy" which implicitly includes affiliated packages.  Indeed the first project is for astroplan.  We could also be explicit and make it "Astropy core and affiliated packages", but I tend to think that's too long.

(This matters since I'm writing up our supporting docs and pages and need a link to the ideas page.  Probably nicer if that link isn't too long with embedded spaces).