### PR TITLE
Add a link to the Astropy GSoC 2016 Guidelines.

### DIFF
--- a/gsoc/gsoc2016/ideas_astropy.md
+++ b/gsoc/gsoc2016/ideas_astropy.md
@@ -5,6 +5,9 @@ show_main: false
 ideas_team: Astropy
 ---
 
+If you are interested in one of the following Astropy Project ideas please see
+the [Astropy GSoC 2016 Guidelines](https://github.com/astropy/astropy/wiki/GSoC-2016-Guidelines)
+for additional information that is specific to Astropy.
 
 ### Implement Scheduling capabilities for Astroplan
 


### PR DESCRIPTION
I'd like to put in a link to the Astropy-specific guidelines here.  Does this look right?  I'm assuming this content will be part of the `{{ body.content }}` tag.