### PR TITLE
fix typo for JuliaAstro github page

### DIFF
--- a/_includes/members/JuliaAstro.html
+++ b/_includes/members/JuliaAstro.html
@@ -6,7 +6,7 @@
     <a href="{{ site.juliaastro_url }}" class="project" target="_blank">JuliaAstro</a> is an organization that shepherds the development of community astronomy and astrophysics packages for Julia. These include packages for widely used functionality such as FITS file I/O, world coordinate systems and cosmological distance calculations.
     <br/>
  <!-- repo -->
-                <a href="https://github.com/juliaasto/" target="_blank">
+                <a href="https://github.com/juliaastro/" target="_blank">
               <span class="icon  icon--github">
                 <svg viewBox="0 0 16 16">
                   <path fill="#333333" d="{{ site.gh_logo }}"/>


### PR DESCRIPTION
Just a short typo fix I noticed on the page, for the link to the JuliaAstro project.