### PR TITLE
Chiantipy links updated to github

### DIFF
--- a/_includes/members/chiantipy.html
+++ b/_includes/members/chiantipy.html
@@ -11,10 +11,10 @@
     used to interpret spectral lines and continua emitted from
     high-temperature, optically-thin astrophysical sources.
     <br/>
-                <a href="http://sourceforge.net/projects/chiantipy/" target="_blank">
+                <a href="https://github.com/chianti-atomic/ChiantiPy" target="_blank">
               <span class="icon  icon--github">
-                <svg viewBox="0 0 15 10">
-                  <path fill="#333333" d="{{ site.sf_logo }}"/>
+                <svg viewBox="0 0 16 16">
+                  <path fill="#333333" d="{{ site.gh_logo }}"/>
                 </svg>
               </span>
              chiantipy</a> 


### PR DESCRIPTION
Fix #57 - though there are few links to update but they are not
available. These are ones in `_config.yml` as `chiantipy_url`.