### PR TITLE
fix mentor rendering in cards

### DIFF
--- a/gsoc/display/partials/tabs/projects.html
+++ b/gsoc/display/partials/tabs/projects.html
@@ -21,8 +21,8 @@
             <div class="card-title name-bear">{{ project.name }}</div>
             <div btf-markdown="project.desc | format_desc" class="card-content markdown"></div>
           </div>  
-          <div ng-show="project.mentors.length>0" class="card-action">
-            <span ng-repeat="mentor in project.mentors | limitTo:4"><a ng-href="https://github.com/{{mentor}}" class="mentors-github-id" target="_blank">{{mentor}}</a></span>
+          <div ng-show="project.mentors.length>0" class="card-action mentors">
+            <span ng-repeat="mentor in project.mentors"><a ng-href="https://github.com/{{mentor}}" class="mentors-github-id" target="_blank">{{mentor}}</a></span>
           </div>
 
 

--- a/gsoc/display/resources/css/style.css
+++ b/gsoc/display/resources/css/style.css
@@ -386,11 +386,15 @@ a:hover > .card{
   color: lightgoldenrodyellow;
   letter-spacing: 0.1em;
 }
+div.mentors{
+  text-align: center;
+}
 .mentors-github-id{
   font-size: 1.2em ;
   color: darkcyan !important;
   text-transform: none !important;
   font-family: 'Roboto Mono', menlo, monospace;
+  display: inline-block;
 }
 .mentors-github-id:hover{
   color: black !important;


### PR DESCRIPTION
I noticed the mentor names in the project cards sometimes run off the edge if there's too many/too-long-named mentors.  This should fix that.  Look good @Cadair and/or @dpshelio ?