### PR TITLE
Two build-related fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ require 'json'
 require 'open-uri'
 versions = JSON.parse(open('https://pages.github.com/versions.json').read)
 
-gem 'github-pages', versions['github-pages']
+gem 'github-pages', group: :jekyll_plugins

--- a/README.md
+++ b/README.md
@@ -21,3 +21,13 @@ To view the site locally, you will then need to run:
 Note that you can watch for changes and automatically rebuild using
 
     jekyll serve --incremental
+
+
+### Submodule
+
+Note that this uses a submodule to complete the build process of the site.  So you may need to do:
+
+    git submodule init
+    git submodule update
+
+in a fresh clone, or just the second line to update the submodule.


### PR DESCRIPTION
This PR does two things based on my most recent attempt to test-build the page:

1. Updates the REAMDE to point out the submodule.  I figured this out on my own, but I'm guessing many potential users wouldn't...
2. Changes the `Gemfile` to use the line github recommends at https://github.com/github/pages-gem .   Without this change `bundler install` was failing for me with an error that it couldn't gind the pages-related gem.  I confess I don't know exactly what this is doing, but it seems likely that following the github-pages recommendation is a good thing to do 

cc @dpshelio 