### PR TITLE
Change yt to use GitHub logo

### DIFF
--- a/_includes/members/yt-project.html
+++ b/_includes/members/yt-project.html
@@ -11,7 +11,7 @@
                 <a href="https://github.com/yt-project/yt" target="_blank">
               <span class="icon  icon--github">
                 <svg height="50%" viewBox="0 0 30 30">
-                  <path fill="#333333" d="{{ site.bb_logo }}"/>
+                  <path fill="#333333" d="{{ site.gh_logo }}"/>
                 </svg>
               </span>
 	      yt_analysis/yt</a>


### PR DESCRIPTION
It looks yt project recently migrated to GitHub. :D

This PR just updates the logo (probably forgotten) that still shows as BitBucket, to GitHub's logo.