### PR TITLE
Update gh logo size for yt

### DIFF
--- a/_includes/members/yt-project.html
+++ b/_includes/members/yt-project.html
@@ -10,7 +10,7 @@
     <br/>
                 <a href="https://github.com/yt-project/yt" target="_blank">
               <span class="icon  icon--github">
-                <svg height="50%" viewBox="0 0 30 30">
+                <svg viewBox="0 0 16 16">
                   <path fill="#333333" d="{{ site.gh_logo }}"/>
                 </svg>
               </span>


### PR DESCRIPTION
Following #154 this makes it so it looks the same size than the others.