### PR TITLE
Adding posts for existing events page

### DIFF
--- a/_posts/2018-08-14-GSoC.md
+++ b/_posts/2018-08-14-GSoC.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: GSoC End of Coding
+title: 2018 August 14: GSoC - End of Coding
 
 date: 2018-08-14
 ---

--- a/_posts/2018-08-14-GSoC.md
+++ b/_posts/2018-08-14-GSoC.md
@@ -1,0 +1,8 @@
+---
+layout: post
+title: GSoC End of Coding
+
+date: 2018-08-14
+---
+
+Students submit their final work product and their final mentor evaluation.

--- a/_posts/2018-09-24-dotastro.md
+++ b/_posts/2018-09-24-dotastro.md
@@ -5,5 +5,5 @@ title: 2018 Septemeber 24-27 - .Astronomy X
 date: 2018-09-24
 ---
 
-The tenth .Astronomy meeting will take place in Baltimore MD from September 
-24-27, 2018. [see here for more info](https://www.dotastronomy.com/home-ten/).
+The [tenth .Astronomy meeting](https://www.dotastronomy.com/home-ten/) will take
+place in Baltimore MD from September 24-27, 2018.

--- a/_posts/2018-09-24-dotastro.md
+++ b/_posts/2018-09-24-dotastro.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: .Astronomy X
+title: 2018 Septemeber 24-27 - .Astronomy X
 
 date: 2018-09-24
 ---

--- a/_posts/2018-09-24-dotastro.md
+++ b/_posts/2018-09-24-dotastro.md
@@ -1,0 +1,9 @@
+---
+layout: post
+title: .Astronomy X
+
+date: 2018-09-24
+---
+
+The tenth .Astronomy meeting will take place in Baltimore MD from September 
+24-27, 2018. [see here for more info](https://www.dotastronomy.com/home-ten/).


### PR DESCRIPTION
I just noticed there's an existing framework for rendering a static events on the OpenAstronomy website [see here](https://openastronomy.org/news.html). This is a first attempt to populate that page with more events.  cc @bsipocz @dpshelio 