### PR TITLE
No SOCIS

### DIFF
--- a/_projects/2018/heliopy/heliopy-units.md
+++ b/_projects/2018/heliopy/heliopy-units.md
@@ -13,7 +13,6 @@ mentors:
  - dpshelio
 initiatives:
  - GSOC
- - SOCIS
 tags:
  - python
  - heliopy

--- a/_projects/2018/poliastro/benchmark-propagators.md
+++ b/_projects/2018/poliastro/benchmark-propagators.md
@@ -15,7 +15,6 @@ mentors:
  - aunsiro
 initiatives:
  - GSOC
- - SOCIS
 tags:
  - python
  - scipy

--- a/_projects/2018/poliastro/export-czml.md
+++ b/_projects/2018/poliastro/export-czml.md
@@ -13,7 +13,6 @@ mentors:
  - newlawrence
 initiatives:
  - GSOC
- - SOCIS
 tags:
  - python
  - javascript

--- a/_projects/2018/poliastro/reference-frames.md
+++ b/_projects/2018/poliastro/reference-frames.md
@@ -14,7 +14,6 @@ mentors:
  - newlawrence
 initiatives:
  - GSOC
- - SOCIS
 tags:
  - python
  - astropy

--- a/_projects/2018/sunpy/mag_field.md
+++ b/_projects/2018/sunpy/mag_field.md
@@ -17,7 +17,6 @@ mentors:
  - wtbarnes
 initiatives:
  - GSOC
- - SOCIS
 tags:
  - python
  - numba

--- a/_projects/2018/sunpy/remote_data.md
+++ b/_projects/2018/sunpy/remote_data.md
@@ -14,7 +14,6 @@ mentors:
  - dpshelio
 initiatives:
  - GSOC
- - SOCIS
 tags:
  - Python
 collaborating_projects:

--- a/_projects/2018/sunpy/sunkit-image.md
+++ b/_projects/2018/sunpy/sunkit-image.md
@@ -14,7 +14,6 @@ mentors:
  - mbobra
 initiatives:
  - GSOC
- - SOCIS
 tags:
  - python
  - sunpy

--- a/_projects/2018/sunpy/time_refactor.md
+++ b/_projects/2018/sunpy/time_refactor.md
@@ -17,7 +17,6 @@ mentors:
  - Punyaslok
 initiatives:
  - GSOC
- - SOCIS
 tags:
  - Python
 collaborating_projects:

--- a/_projects/2019/poliastro/export-czml.md
+++ b/_projects/2019/poliastro/export-czml.md
@@ -13,7 +13,6 @@ mentors:
  - AunSiro
 initiatives:
  - GSOC
- - SOCIS
 tags:
  - python
  - javascript

--- a/_projects/2019/sunpy/featuresevents.md
+++ b/_projects/2019/sunpy/featuresevents.md
@@ -15,7 +15,6 @@ mentors:
  - dpshelio
 initiatives:
  - GSOC
- - SOCIS
 tags:
  - Python
 collaborating_projects:

--- a/_projects/2019/sunpy/helioviewer.md
+++ b/_projects/2019/sunpy/helioviewer.md
@@ -15,7 +15,6 @@ mentors:
  - Helioviewer-Kirill
 initiatives:
  - GSOC
- - SOCIS
 tags:
  - python
 collaborating_projects:

--- a/_projects/2019/sunpy/irispy_response.md
+++ b/_projects/2019/sunpy/irispy_response.md
@@ -16,7 +16,6 @@ mentors:
  - asainz-solarphysics
 initiatives:
  - GSOC
- - SOCIS
 tags:
 # Different technologies needed
  - python

--- a/_projects/2019/sunpy/ndcube_ape14.md
+++ b/_projects/2019/sunpy/ndcube_ape14.md
@@ -16,7 +16,6 @@ mentors:
  - Cadair
 initiatives:
  - GSOC
- - SOCIS
 tags:
 # Different technologies needed
  - python

--- a/_projects/2019/sunpy/remote_data.md
+++ b/_projects/2019/sunpy/remote_data.md
@@ -13,7 +13,6 @@ mentors:
  - dpshelio
 initiatives:
  - GSOC
- - SOCIS
 tags:
  - Python
 collaborating_projects:

--- a/_projects/2019/sunpy/sunkit_image.md
+++ b/_projects/2019/sunpy/sunkit_image.md
@@ -20,7 +20,6 @@ mentors:
  - wafels
 initiatives:
  - GSOC
- - SOCIS
 tags:
  - python
  - numpy


### PR DESCRIPTION
Remove SOCIS references for these projects that are not part of the [accepted SOCIS projects](https://socis.esa.int/projects/) - for 2018 and 2019.