### PR TITLE
Creates a Contact entry to each idea

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ bundle exec jekyll serve
 this will track the changes and rebuild automatically. However, it won't reflect changes on `_config.yaml` 
 
 
+### Building using a Jekyll container
+
+```bash
+mkdir -p ../vendor/bundle # so it's available for other projects
+export JEKYLL_VERSION=3.8
+# only needs to run it once to download the dependencies
+docker run --rm -e BUNDLE_APP_CONFIG="/srv/vendor/bundle" -e BUNDLE_HOME="/srv/vendor/bundle" -e BUNDLE_PATH="/srv/vendor/bundle" --volume="$PWD:/srv/jekyll" --volume="$PWD/../vendor:/srv/vendor" -it jekyll/jekyll:$JEKYLL_VERSION  bundle install
+# build
+docker run --rm -e BUNDLE_APP_CONFIG="/srv/vendor/bundle" -e BUNDLE_HOME="/srv/vendor/bundle" -e BUNDLE_PATH="/srv/vendor/bundle" --volume="$PWD:/srv/jekyll" --volume="$PWD/../vendor:/srv/vendor" -it jekyll/jekyll:$JEKYLL_VERSION  bundle exec jekyll build
+# serve from python
+python -m http.server -d _site_
+```
+
 ### Submodule
 
 Note that this uses a submodule to complete the build process of the site.  So you may need to do:

--- a/_data/members.yaml
+++ b/_data/members.yaml
@@ -198,7 +198,7 @@ heliopy:
   repositories:
     github: heliopython/heliopy
   mailinglist:
-    general: https://groups.google.com/group/plasmapy
+    users: https://groups.google.com/group/plasmapy
   chat:
     matrix: https://riot.im/app/#/room/#heliopy:matrix.org
   description: >-
@@ -213,8 +213,8 @@ gnuastro:
   repositories:
     savannah: https://git.savannah.gnu.org/cgit/gnuastro.git
   mailinglist:
-    user: https://lists.gnu.org/mailman/listinfo/help-gnuastro
-    dev: https://lists.gnu.org/mailman/listinfo/gnuastro-devel
+    users: https://lists.gnu.org/mailman/listinfo/help-gnuastro
+    devs: https://lists.gnu.org/mailman/listinfo/gnuastro-devel
   description: >-
     (Gnuastro) is an official GNU package consisting of many
     <a href="https://www.gnu.org/software/gnuastro/manual/html_node/Gnuastro-programs-list.html"
@@ -260,7 +260,7 @@ plasmapy:
   repositories:
     github: plasmapy/plasmapy
   mailinglist:
-    general: https://groups.google.com/group/plasmapy
+    users: https://groups.google.com/group/plasmapy
   chat:
     matrix: https://riot.im/app/#/room/#plasmapy:matrix.org
   description: >-

--- a/gsoc/display/data/admins.js
+++ b/gsoc/display/data/admins.js
@@ -1,4 +1,6 @@
 admins = {2017: ["dpshelio", "Cadair", "taldcroft", "eteq"],
           2018: ["dpshelio", "bsipocz"],
           2019: ["dpshelio", "bsipocz", "mirca"],
-          2020: ["dpshelio", "bsipocz", "mirca"]};
+          2020: ["dpshelio", "bsipocz", "mirca"],
+          2021: ["dpshelio", "bsipocz", "mirca"],
+         };

--- a/gsoc/display/partials/tabs/projects.html
+++ b/gsoc/display/partials/tabs/projects.html
@@ -84,6 +84,11 @@
           <span ng-click="redirect(issue)" class="pr-element-detail chip clickable" ng-repeat="issue in currentProject.issues">{{ issue | format_issue }}</span>
         </div>
         <br>
+        <div ng-show="currentProject.collaborating_projects.length>0" class="project-detail-element">
+            <div class="heading">Show interest on this project by:</div>
+            <a class="pr-element-detail chip clickable" ng-repeat="project in currentProject.collaborating_projects" href="{{ project | format_project }}">chat/mail</a>
+        </div>
+        <br>
       </div>
 
       <div class="col-md-8 dashboard">

--- a/gsoc/display/resources/js/app.js
+++ b/gsoc/display/resources/js/app.js
@@ -122,6 +122,35 @@
   };
  });
 
+ app.filter('format_project', function () {
+  return function (value) {
+      if (!value) return '';
+      var all =  {{ site.data.members | jsonify }};
+      if (value in all) {
+          var data = all[value];
+          if ('chat' in data){
+              if ('matrix' in data.chat) {
+                  return data.chat['matrix'];
+              } else if ('slack' in data.chat) {
+                  return data.chat['slack'];
+              } else if ('gitter' in data.chat) {
+                  return data.chat['gitter'];
+              }
+          };
+          if ('mailinglist' in data){
+              if ('devs' in data.mailinglist) {
+                  return data.mailintlist['devs'];
+              } else if ('users' in data.mailinglist) {
+                  return data.mailinglist['users'];
+              };
+          };
+      };
+      return 'https://riot.im/app/#/room/#openastronomy:matrix.org';
+  };
+ });
+
+
+
 
 	app.directive('mentors', ['$http', function ($http) {
 		return {

--- a/gsoc/gsoc2021/index.md
+++ b/gsoc/gsoc2021/index.md
@@ -1,0 +1,6 @@
+---
+layout: projects
+title:  "Ideas page for Google Summer of Code 2021"
+show_main: false
+season: 2021
+---

--- a/gsoc/index.md
+++ b/gsoc/index.md
@@ -8,11 +8,11 @@ permalink: /gsoc/
  
 [Background on GSoC: start here!](./background.html)
 
-## GSoC/Open Astronomy 2020
+## GSoC/Open Astronomy 2021
 
 OpenAstronomy is an umbrella organisation which collects project ideas
 from any of its members. OpenAstronomy was a GSOC mentoring organisation since 2016 and
-it's applying to participate in 2020.
+it's applying to participate in 2021.
 
 Student applications to OpenAstronomy projects follows the same
 rules as the [Python Software Foundation] and the [GSoC Student Guide],
@@ -28,6 +28,7 @@ All the student blogs are collected in the [OpenAstronomy Universe] site.
 
 ## Ideas Pages
 
+* [2021](./gsoc2021/)
 * [2020](./gsoc2020/)
 * [2019](./gsoc2019/)
 * [2018](./gsoc2018/)


### PR DESCRIPTION
Each idea now has a link to contact. 
Defaults to the chat of the organisation or to the dev/user mailinglist. 
If we don't have that data in our members list, then defaults to the matrix channel of open astronomy.

This is a solution to #258