### PR TITLE
Link to discussion page added for Gnuastro's projects

### DIFF
--- a/_projects/2021/gnuastro/astrometry.md
+++ b/_projects/2021/gnuastro/astrometry.md
@@ -35,6 +35,7 @@ In short, astrometry is the process of finding the transformation matrix (includ
 Gnuastro's astrometry library aims to be fully blind, needing no prior information on the input image's location in the sky, or the optical distortion of the camera that has taken the image.
 Many of the low-level components of astrometry have already been added in Gnuastro's new implementation.
 However some work still remains on stitching them together into a simple-to-use, high-level C library function that can later be used in several Gnuastro programs, as well as other programs and languages.
+To get started, a checklist has been prepared at http://savannah.gnu.org/support/?110457#comment0
 
 #### Milestones (if any)
 

--- a/_projects/2021/gnuastro/astrometry.md
+++ b/_projects/2021/gnuastro/astrometry.md
@@ -35,7 +35,7 @@ In short, astrometry is the process of finding the transformation matrix (includ
 Gnuastro's astrometry library aims to be fully blind, needing no prior information on the input image's location in the sky, or the optical distortion of the camera that has taken the image.
 Many of the low-level components of astrometry have already been added in Gnuastro's new implementation.
 However some work still remains on stitching them together into a simple-to-use, high-level C library function that can later be used in several Gnuastro programs, as well as other programs and languages.
-To get started, a checklist has been prepared at http://savannah.gnu.org/support/?110457#comment0
+To get started, check [our checklist](http://savannah.gnu.org/support/?110457#comment0)
 
 #### Milestones (if any)
 

--- a/_projects/2021/gnuastro/python-wrapper.md
+++ b/_projects/2021/gnuastro/python-wrapper.md
@@ -39,6 +39,7 @@ Gnuastro therefore plans on adding a low-level wrapper infra-structure which wil
 Note that this won't involve intermediate wrapper languages SWIG, we will directly link with the core C library of Numpy: https://docs.scipy.org/doc/numpy-1.10.0/reference/c-api.html
 This will be a wonderful chance to master Python and Scipy/Numpy at a very fundamental level, giving you a great experience to expand what you have learnt afterwards into many other functionalities.
 Of course, in the meantime you will also working on many real-world astronomical data and science scenarios using ground-based and space-based data.
+To get started, a checklist has been prepared at http://savannah.gnu.org/support/?110457#comment0
 
 #### Milestones (if any)
 

--- a/_projects/2021/gnuastro/python-wrapper.md
+++ b/_projects/2021/gnuastro/python-wrapper.md
@@ -39,7 +39,7 @@ Gnuastro therefore plans on adding a low-level wrapper infra-structure which wil
 Note that this won't involve intermediate wrapper languages SWIG, we will directly link with the core C library of Numpy: https://docs.scipy.org/doc/numpy-1.10.0/reference/c-api.html
 This will be a wonderful chance to master Python and Scipy/Numpy at a very fundamental level, giving you a great experience to expand what you have learnt afterwards into many other functionalities.
 Of course, in the meantime you will also working on many real-world astronomical data and science scenarios using ground-based and space-based data.
-To get started, a checklist has been prepared at http://savannah.gnu.org/support/?110457#comment0
+To get started, check [our checklist](http://savannah.gnu.org/support/?110457#comment0).
 
 #### Milestones (if any)
 


### PR DESCRIPTION
Until now Sachin had only put the link containing a checklist of steps
to do on the Matrix chat page. However, with newer chats coming down,
they were not easily findable.

With this commit, a sentence has been added at the end of the two
ideas the point interested students directly to the proper place to
get started.