### PR TITLE
GSOC: Add more detail on "open a PR" requirement

### DIFF
--- a/gsoc/student_guidelines.md
+++ b/gsoc/student_guidelines.md
@@ -53,7 +53,12 @@ developer guides are great reads no matter what project you are thinking of work
 Checkout the issue lists of the projects to see if there is something that you could do.
 **You will be expected to submit a pull request to one of the OpenAstronomy projects before
 you submit your application (it does not have to be accepted, but it has to be something
-that shows your code abilities!).**
+that shows your code abilities!).** This requirement is to show that you know how git, github,
+pull requests and reviews work and allows mentors to eveluate all applications based on a real code 
+contribution, instead of e.g. the name of a specific school. 
+GSOC is a short program and we want to make sure you are
+ready to start immediately. If you have previously contributed to OpenAstronomy projects,
+you can point to those pull requests, too.
 
 5. **Plan your application.**
 Think which is your favourite project from the [ideas page](/gsoc/) or think


### PR DESCRIPTION
This change of text is based on feedback from our GSOC student this year. To them, the "need to open at least on PR" seemed burdensome. I think we agree now that this requirement is good for all (students and mentors) because it puts all students on equal footing - applications are judged based on real PRs, not the perceived quality of one school over another. However, it helps to have a short explanation in the text and it also helps to make clear that we don't want to create extra work. If an applicant has contributed to OA projects in the past, that should be sufficient and not require a new PR in the exact timeframe of the GSOC application.
@aaryapatil @suyog7130