### PR TITLE
Fixed the size of background image in mobile devices

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -24,6 +24,14 @@ body {
     background-color: $background-color;
     -webkit-text-size-adjust: 100%;
     height:100%;
+
+    @include media-query($on-laptop) {
+        background-size: 200%;
+    }
+
+    @include media-query($on-palm) {
+        background-size: 300%;
+    }
 }
 
 

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -41,9 +41,9 @@
         }
     }
 
-    @include media-query($on-palm) {
+    @include media-query($on-desktop) {
         position: absolute;
-        top: 9px;
+        top: 20px;
         right: 30px;
         background-color: $menu-color;
         border: 1px solid $grey-color-light;
@@ -64,7 +64,7 @@
                 height: 15px;
 
                 path {
-                    fill: $grey-color-dark;
+                    fill: white;
                 }
             }
         }

--- a/css/main.scss
+++ b/css/main.scss
@@ -22,8 +22,9 @@ $grey-color:       #333333;
 $grey-color-light: lighten($grey-color, 40%);
 $grey-color-dark:  darken($grey-color, 25%);
 
-$on-palm:          1060px;
+$on-palm:          600px;
 $on-laptop:        800px;
+$on-desktop:       1060px;
 
 
 


### PR DESCRIPTION
Fixes: #292 
Fixed the size of background image in mobile devices and also fixed the color of the svg for navigation bar (as the previous black color was matching with the background).