### PR TITLE
Updates CIRCLE config to the new branch name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
       - run:
           name: HTMLProofer with external
           command: |
-            if [ "${CIRCLE_BRANCH}" = "master" ]; then
+            if [ "${CIRCLE_BRANCH}" = "main" ]; then
              bundle exec htmlproofer ./html \
                --allow-hash-href \
                --check-html \


### PR DESCRIPTION
The `master` branch is now named `main`. As such, this required a small update to get our CI working right.