### PR TITLE
CI-fix - ignores links from previous years

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
              bundle exec htmlproofer ./html \
                --allow-hash-href \
                --check-html \
-               --file-ignore "/.+\/gsoc\/display\/partials.+/","/.+\/gsoc\/gsoc20[15-21].+/","/.+\/html/projects/20[15-21].+/" \
+               --file-ignore "/.+\/gsoc\/display\/partials.+/","/.+\/gsoc\/gsoc201[5-9].+/","/.+\/html/projects/201[5-9].+/","/.+\/gsoc\/gsoc202[0-1].+/","/.+\/html/projects/202[0-1].+/" \
                --http-status-ignore 302
                # Ignore old ideas pages and ssl certificates that error.
             fi


### PR DESCRIPTION
The previous attempt on #304 failed because sequences with multi-digit numbers are not understood.
i.e., `[15-21]`, needs to be broken into two: `1[5-9]` and `2[0-1]`.