### PR TITLE
Remove socis from 2022 project ideas

### DIFF
--- a/_projects/2022/gnuastro/astrometry_distortions.md
+++ b/_projects/2022/gnuastro/astrometry_distortions.md
@@ -17,7 +17,6 @@ mentors:
 initiatives:
 # The programme under this project wish to run.
  - GSOC
- - SOCIS
 project_size:
  - 175 h
 tags:

--- a/_projects/2022/gnuastro/python_wrappers.md
+++ b/_projects/2022/gnuastro/python_wrappers.md
@@ -16,7 +16,6 @@ mentors:
 initiatives:
 # The programme under this project wish to run.
  - GSOC
- - SOCIS
 project_size:
  - 350 h
 tags:


### PR DESCRIPTION
SOCIS is not advertized for this year, so we better remove it from the project ideas.

I also wonder @mohammad-akhlaghi whether there is someone else who are willing to be listed as secondary mentor for the GNUastro projects?