### PR TITLE
MAINT: cleanup website issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-       - image: circleci/ruby:2.5
+       - image: cimg/ruby:2.5
     environment:
       BUNDLE_PATH: ~/vendor/bundle
 

--- a/_data/members.yaml
+++ b/_data/members.yaml
@@ -135,8 +135,6 @@ timelab:
   url: http://www.timelabtechnologies.com
   repositories:
     github: StingraySoftware
-  chat:
-    slack: http://slack-invite.timelabtechnologies.com
   description: >-
     : we are a team of astrophysicists and software developers working together
     to build a variability analysis software to study black holes and

--- a/_data/members.yaml
+++ b/_data/members.yaml
@@ -23,7 +23,7 @@ astronomy-commons:
   mailinglist:
     devs: https://groups.google.com/forum/#!forum/astronomy-commons
   chat:
-    matrix: https://riot.im/app/#/room/#astronomy-commons:matrix.org 
+    matrix: https://riot.im/app/#/room/#astronomy-commons:matrix.org
   description: >-
     is an initiative for software infrastructure for science platforms and
     scalable astronomy on cloud resources. Astronomy Data Commons is lead by
@@ -190,21 +190,6 @@ coin:
     astronomers, statisticians and machine learning experts can flourish. COIN
     is designed to promote the development of a new family of tools for data
     exploration in astrophysics and cosmology.
-
-heliopy:
-  name: HelioPy
-  logo: heliopy.png
-  url: http://heliopy.org
-  repositories:
-    github: heliopython/heliopy
-  mailinglist:
-    users: https://groups.google.com/group/plasmapy
-  chat:
-    matrix: https://riot.im/app/#/room/#heliopy:matrix.org
-  description: >-
-    is a python package for space physics, that aims to provide the tools to
-    find, download and analyse spacecraft data from across the whole solar
-    system.
 
 gnuastro:
   name: GNU Astronomy Utilities


### PR DESCRIPTION
To close #329. 

We may want to do more about the heliopy website, e.g. the linkcheck should not fail for the old project list (neither should the old link removed from that page)