### PR TITLE
Sort members list alphabetically 

### DIFF
--- a/members.md
+++ b/members.md
@@ -7,7 +7,8 @@ permalink: /members/
 ## Who is part of OpenAstronomy?
 
 <div class="row-fluid">
-{% for member in site.data.members %}
+{% assign sorted_members = site.data.members | sort %}
+{% for member in sorted_members %}
   <div class="span6" style="padding-bottom:15px">{% include member.html member=member%}</div>
   {% cycle '', '</div>' %}
   {% cycle '', '<div class="row-fluid">' %}


### PR DESCRIPTION
Fixes #252. As suggested by @nabobalis, this PR sorts the members list alphabetically using the Liquid sort filter.