### PR TITLE
Improve sub-org contact visibility for GSoC students

### DIFF
--- a/_includes/suborg_contacts.html
+++ b/_includes/suborg_contacts.html
@@ -1,0 +1,54 @@
+{% comment %}
+This include displays contact information for a specific sub-organisation.
+Usage: {% include suborg_contacts.html suborg="sunpy" %}
+{% endcomment %}
+
+{% assign suborg_name = include.suborg | downcase %}
+{% assign suborg_data = site.data.members[suborg_name] %}
+
+{% if suborg_data %}
+<div class="suborg-contact-info" style="background-color: #f5f5f5; padding: 15px; margin: 20px 0; border-left: 4px solid #2196F3;">
+  <h4 style="margin-top: 0;">📬 Contact {{ suborg_data.name }}</h4>
+  <p>Interested in this project? Get in touch with the {{ suborg_data.name }} community:</p>
+  <ul style="margin-bottom: 0;">
+    {% if suborg_data.chat %}
+      {% if suborg_data.chat.matrix %}
+        <li><strong>Chat (Matrix):</strong> <a href="{{ suborg_data.chat.matrix }}" target="_blank">Join Matrix channel</a></li>
+      {% endif %}
+      {% if suborg_data.chat.slack %}
+        <li><strong>Chat (Slack):</strong> <a href="{{ suborg_data.chat.slack }}" target="_blank">Join Slack workspace</a></li>
+      {% endif %}
+      {% if suborg_data.chat.gitter %}
+        <li><strong>Chat (Gitter):</strong> <a href="{{ suborg_data.chat.gitter }}" target="_blank">Join Gitter channel</a></li>
+      {% endif %}
+      {% if suborg_data.chat.zulip %}
+        <li><strong>Chat (Zulip):</strong> <a href="{{ suborg_data.chat.zulip }}" target="_blank">Join Zulip channel</a></li>
+      {% endif %}
+      {% if suborg_data.chat.irc %}
+        <li><strong>Chat (IRC):</strong> <a href="{{ suborg_data.chat.irc }}" target="_blank">Join IRC channel</a></li>
+      {% endif %}
+    {% endif %}
+    {% if suborg_data.mailinglist %}
+      {% if suborg_data.mailinglist.users %}
+        <li><strong>User mailing list:</strong> <a href="{{ suborg_data.mailinglist.users }}" target="_blank">Subscribe here</a></li>
+      {% endif %}
+      {% if suborg_data.mailinglist.devs %}
+        <li><strong>Developer mailing list:</strong> <a href="{{ suborg_data.mailinglist.devs }}" target="_blank">Subscribe here</a></li>
+      {% endif %}
+      {% if suborg_data.mailinglist.admin %}
+        <li><strong>Contact admin:</strong> <a href="{{ suborg_data.mailinglist.admin }}" target="_blank">Email admin</a></li>
+      {% endif %}
+    {% endif %}
+    {% if suborg_data.url %}
+      <li><strong>Website:</strong> <a href="{{ suborg_data.url }}" target="_blank">{{ suborg_data.url }}</a></li>
+    {% endif %}
+  </ul>
+  <p style="margin-top: 10px; margin-bottom: 0; font-size: 0.9em; color: #666;">
+    <em>Remember: Contact mentors in public channels rather than via direct messages or email.</em>
+  </p>
+</div>
+{% else %}
+<div class="suborg-contact-info" style="background-color: #fff3cd; padding: 15px; margin: 20px 0; border-left: 4px solid #ffc107;">
+  <p><strong>Note:</strong> For contact information about this project, please refer to the <a href="/gsoc/student_guidelines.html#sub-organisation-contact-information">Student Guidelines</a>.</p>
+</div>
+{% endif %}

--- a/_projects/2025/radis/Fast_Parsing.md
+++ b/_projects/2025/radis/Fast_Parsing.md
@@ -29,6 +29,8 @@ collaborating_projects:
  - radis
 ---
 
+{% include suborg_contacts.html suborg="radis" %}
+
 #### Description
 
 The RADIS code was developed for the characterization of plasmas, flames and atmospheres.

--- a/_projects/2025/stingray/interactive_database.md
+++ b/_projects/2025/stingray/interactive_database.md
@@ -32,6 +32,8 @@ collaborating_projects:
 
 # Interactive Database for X-ray observations 
 
+{% include suborg_contacts.html suborg="stingray" %}
+
 ## Description
 
 The increasing number of X-ray telescopes observing accreting black hole sources 

--- a/_projects/README.md
+++ b/_projects/README.md
@@ -1,39 +1,84 @@
-# How to add project ideas for OpenAstronomy
+# Project Ideas
 
-This short tutorial will guide you on how to add a GSoC project idea in the
-OpenAstronomy website.
+This directory contains project ideas for OpenAstronomy's participation in programs like Google Summer of Code (GSoC).
 
-In case you face any issues with this tutorial do contact your org admins via email,
-thorough the [mailing list](https://groups.google.com/forum/#!forum/openastronomy).
+## Directory Structure
 
-*tl;dr: are you an expert?* Fork the repo and modify
-the [template file](./_template.md) according to your idea, save it under
-`_projects/YYYY/sub-org/` with a meaningful filename and open a pull-request.
+Projects are organized by year and sub-organisation:
+```
+_projects/
+├── YYYY/
+│   ├── suborg1/
+│   │   ├── project1.md
+│   │   └── project2.md
+│   └── suborg2/
+│       └── project3.md
+└── _template.md
+```
 
-## What do I need for my project idea?
+## Creating a New Project Idea
 
-Everything you need is a title and description of the project idea, a set of requirements
-for potential students (_e.g._, proficiency with `astropy.tables` and `astropy.units`),
-and a list of potential mentors. In addition, please link any related issues or tickets
-to the project idea, if any. Lastly, make sure to indicate the level of difficulty of
-the project.
+1. Copy `_template.md` to the appropriate year and sub-organisation directory
+2. Fill in all the required fields in the YAML front matter
+3. Write a clear description of the project
+4. **Add contact information** for your sub-organisation (see below)
+5. Define clear milestones for the project timeline
+6. Submit a pull request
 
-In case your project idea already has specific milestones, please add them
-so as to make students aware when they start writing their applications.
-If the project milestones are open ended and you would like to hear input from
-other members of the community, that is fine too!
+## Adding Sub-Organisation Contact Information
 
-## Required format
+To help students reach your community, add contact information to your project page by including this line right after the project title:
 
-Given that you have the above items, all you need now is to put them in a plain text file following
-the [template file](./_template.md) (you may click on `Code` to see how it looks).
+```liquid
+{% include suborg_contacts.html suborg="yoursuborg" %}
+```
 
-The file is composed in two parts (separated by a `---`).
-Change the text in the template keeping special care of the structure of the `yaml`
-file and the headings on the markdown part (_e.g._, the top level starts with a 4 level title: `####`).
+Replace `yoursuborg` with your sub-organisation's key from `_data/members.yaml` (e.g., `sunpy`, `astropy`, `radis`, `stingray`).
 
-## How to include my project idea on the website?
+This will automatically display:
+- Chat channels (Matrix, Slack, Gitter, etc.)
+- Mailing lists (users, developers)
+- Website link
+- A reminder to contact mentors in public channels
 
-If you are familiar with git/GitHub: for this repo and add your project idea
-to the directory of your sub-organisation. Otherwise, we've got you covered!
-Contact us via [email](openastronomy.organization@gmail.com) and attach the above file.
+### Example
+
+```markdown
+---
+name: My Awesome Project
+collaborating_projects:
+ - sunpy
+---
+
+# My Awesome Project
+
+{% include suborg_contacts.html suborg="sunpy" %}
+
+## Description
+...
+```
+
+## Updating Contact Information
+
+Contact information is centrally managed in `_data/members.yaml`. To update your sub-organisation's contact details:
+
+1. Edit `_data/members.yaml`
+2. Update the relevant fields under your sub-organisation's entry
+3. The changes will automatically appear on all project pages using the include
+
+## Template Fields
+
+See `_template.md` for all available fields and their descriptions. Key fields include:
+
+- `name`: Project title
+- `desc`: One-line description
+- `requirements`: Student prerequisites
+- `difficulty`: low, medium, or high
+- `mentors`: GitHub/GitLab handles
+- `collaborating_projects`: Sub-organisation(s)
+- `project_size`: Expected time commitment
+- `tags`: Technologies involved
+
+## Questions?
+
+For questions about creating project ideas, contact the OpenAstronomy admins or refer to the [Sub-Org Guidelines](/gsoc/suborg_guidelines.html).

--- a/_projects/_template.md
+++ b/_projects/_template.md
@@ -36,6 +36,13 @@ collaborating_projects:
 
 # This is an awesome project idea for suborg.
 
+{% comment %}
+Add contact information for your sub-organisation by including the line below.
+Replace "astropy" with your suborg name (lowercase, matching the key in _data/members.yaml).
+This will automatically display chat channels, mailing lists, and other contact info.
+{% endcomment %}
+{% include suborg_contacts.html suborg="astropy" %}
+
 ## Description
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus aliquam

--- a/gsoc/student_guidelines.md
+++ b/gsoc/student_guidelines.md
@@ -27,9 +27,8 @@ There are many ways to get yourself known by the community, you can introduce yo
 OpenAstronomy mailing list ([how to use Google Groups](https://support.google.com/groups/answer/1046523?hl=en)), chat with us in the Matrix channel ([how to connect to matrix](https://element.io/user-guide)) and if required contact the mentors to know
 more about certain project. However, contacting mentors through email or direct messages is discouraged, and contacting them in public channels is the preferred way to provide answers to multiple people at once. Also, when you have a particular idea in
 mind, get in touch with that project and introduce yourself.
-For `astropy` projects you can do this by sending an e-mail to the
-[astropy-gsoc-applications](<mailto:astropy-gsoc-applications@googlegroups.com>) mailing list
-(please do not send to the `astropy-dev` list).
+
+**Each sub-organisation has its own communication channels.** See the [Sub-Organisation Contact Information](#sub-organisation-contact-information) section below for specific details on how to reach each project's community.
 
 2. **Become a user!**
 Download one or more of the OpenAstronomy projects and start experimenting with the code.
@@ -77,6 +76,66 @@ Don't forget to [submit your application](https://summerofcode.withgoogle.com/) 
 We are also happy to give comments on your proposal if you like.  Feel free to
 add your application to the sub-org member's wiki following this format: "GSoC-\<YEAR\> Application \<sub-org\> \<Your Name\>:\<Project Name\>"
 and link such page in [the wiki](https://github.com/OpenAstronomy/openastronomy/wiki).
+
+## Sub-Organisation Contact Information
+
+Each OpenAstronomy sub-organisation has its own community and communication channels. When you're interested in a specific project, make sure to reach out through the appropriate channels for that organisation:
+
+### Astropy
+- **Application mailing list**: [astropy-gsoc-applications@googlegroups.com](mailto:astropy-gsoc-applications@googlegroups.com) (please do not send to the `astropy-dev` list)
+- **Chat**: [Slack](http://joinslack.astropy.org/)
+- **User mailing list**: [astropy users](http://mail.python.org/mailman/listinfo/astropy)
+- **Developer mailing list**: [astropy-dev](http://groups.google.com/group/astropy-dev)
+
+### Astronomy Data Commons
+- **Developer mailing list**: [astronomy-commons](https://groups.google.com/forum/#!forum/astronomy-commons)
+- **Chat**: [Matrix](https://app.element.io/#/room/#astronomy-commons:matrix.org)
+
+### CTLearn
+- **Chat**: [Matrix](https://app.element.io/#/room/#ctlearn:matrix.org)
+
+### EinsteinPy
+- **Developer mailing list**: [einsteinpy-dev](https://groups.io/g/einsteinpy-dev)
+- **Chat**: [Matrix](https://app.element.io/#/room/#einsteinpy:matrix.org)
+
+### Glue
+- **User mailing list**: [glue-viz](https://groups.google.com/group/glue-viz)
+- **Developer mailing list**: [glue-viz-dev](https://groups.google.com/group/glue-viz-dev)
+
+### GNU Astronomy Utilities (Gnuastro)
+- **User mailing list**: [help-gnuastro](https://lists.gnu.org/mailman/listinfo/help-gnuastro)
+- **Developer mailing list**: [gnuastro-devel](https://lists.gnu.org/mailman/listinfo/gnuastro-devel)
+
+### JuliaAstro
+- **User forum**: [Julia Discourse - Astronomy](https://discourse.julialang.org/c/domain/astro)
+- **Chat**: [Slack](https://app.slack.com/client/T68168MUP/CMXU6SD7V) or [Zulip](https://julialang.zulipchat.com/#narrow/channel/astronomy)
+
+### PlasmaPy
+- **User mailing list**: [plasmapy](https://groups.google.com/group/plasmapy)
+- **Chat**: [Matrix](https://app.element.io/#/room/#plasmapy:matrix.org)
+
+### poliastro
+- **Developer mailing list**: [poliastro-dev](https://groups.io/g/poliastro-dev)
+- **Chat**: [Matrix](https://app.element.io/#/room/#poliastro:matrix.org)
+
+### RADIS
+- **User mailing list**: [radis-radiation](https://groups.google.com/forum/#!forum/radis-radiation)
+- **Chat**: [Gitter](https://gitter.im/radis-radiation/community)
+
+### Stingray
+- **Chat**: [Slack](https://join.slack.com/t/stingraysoftware/shared_invite/zt-49kv4kba-mD1Y~s~rlrOOmvqM7mZugQ)
+
+### SunPy
+- **User mailing list**: [sunpy](http://groups.google.com/group/sunpy)
+- **Developer mailing list**: [sunpy-dev](http://groups.google.com/group/sunpy-dev)
+- **Chat**: [Matrix](https://app.element.io/#/room/#sunpy:openastronomy.org)
+
+### yt
+- **User mailing list**: [yt-users](https://mail.python.org/archives/list/yt-users@python.org/)
+- **Developer mailing list**: [yt-dev](https://mail.python.org/archives/list/yt-dev@python.org/)
+- **Chat**: [Slack](https://yt-project.slack.com/)
+
+**Note**: For organisations not listed above or for general OpenAstronomy questions, use the main OpenAstronomy communication channels mentioned at the top of this guide.
 
 [SymPy Guidelines]: https://github.com/sympy/sympy/wiki/GSoC-2017-Application-Template
 [Python Software Foundation]: http://python-gsoc.org/

--- a/gsoc/suborg_guidelines.md
+++ b/gsoc/suborg_guidelines.md
@@ -61,6 +61,11 @@ Take a look at [how others have done it before](https://github.com/OpenAstronomy
 The admins and other members will review your ideas and provide feedback. Once
 done, they will be merged and displayed on our website.
 
+**Important**: To help students reach your community, include contact information on each project page
+by adding `{% include suborg_contacts.html suborg="yoursuborg" %}` right after the project title.
+This automatically displays your chat channels, mailing lists, and website from `_data/members.yaml`.
+See the [project template](https://github.com/OpenAstronomy/openastronomy.github.io/blob/master/_projects/_template.md) for an example.
+
 It's also possible that a contributor comes up with their own ideas! That's OK, the
 only limitation is that either the contributor or the admin will have to find a
 mentor for that idea who is familiar with the programming language, the repository,


### PR DESCRIPTION
- Add comprehensive Sub-Organisation Contact Information section to student guidelines
- Create reusable suborg_contacts.html include for displaying contact info on project pages
- Update project template to include contact widget with clear instructions
- Add _projects/README.md with documentation for creating project ideas
- Update suborg guidelines to mention the new contact include feature
- Add contact widgets to 2025 RADIS and Stingray projects as examples

This addresses the issue where students have difficulty finding the correct communication channels for specific sub-organisations, often ending up in the wrong mailing lists or chat rooms (e.g., heliopy students contacting astropy channels). Now students can find all contact info in one central location in the guidelines, and each project page can display relevant sub-org contact information directly.