### PR TITLE
Improve visibility of chat links in student guide

### DIFF
--- a/gsoc/student_guidelines.md
+++ b/gsoc/student_guidelines.md
@@ -8,17 +8,11 @@ show_main: false
 
 **Communication Channels**
 
-
-OpenAstronomy is a federation of many different organizations (like SunPy, Astropy, etc.).
-To get help, you need to find the specific project you are interested in:
+OpenAstronomy is a collaboration between open source astronomy and astrophysics projects and as such, to get help you need to find the specific project you are interested in:
 
 1.  Browse the **[Project Ideas Page](/gsoc/)** to find a project that interests you.
 2.  Check the **[Members Page](/members)** to find the chat links for that specific organization.
 3.  Join *that* organization's chat to talk to the mentors!
-
-**Mailing List**
-
-You can also join the [OpenAstronomy mailing list](https://groups.google.com/forum/#!forum/openastronomy) to receive announcements and ask general questions.
 
 ---
 


### PR DESCRIPTION
Fixes #155. I added a clear 'Communication Channels' section to the top of the GSoC guide so new students can easily find the Matrix chat and mailing list.